### PR TITLE
Truly and successfully enabled JPA(Hibernate) and MybatisPlus Primary Key generating strategy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,11 @@
     <description>A Distribute system primary key generating strategy for JPA(Hibernate) and Mybatis developed base on @Twitter SnowFlake.</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <spring.boot.version>2.6.4</spring.boot.version>
         <hibernate.version>5.6.7.Final</hibernate.version>
+        <mybatisPlus.version>3.5.1</mybatisPlus.version>
     </properties>
 
     <dependencies>
@@ -40,6 +41,12 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <version>${mybatisPlus.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/github/hexdude/generator/JPAGenerator.java
+++ b/src/main/java/com/github/hexdude/generator/JPAGenerator.java
@@ -4,18 +4,16 @@ import com.github.hexdude.core.Core;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.IdentifierGenerator;
-import org.springframework.stereotype.Component;
 
 import java.io.Serializable;
 
 /**
  * @author HEXDude
  * @date 2022/3/21
- * @description
+ * @description Customized Primary Key generating strategy for JPA(Hibernate).
  */
 @SuppressWarnings("AlibabaClassNamingShouldBeCamel")
-@Component
-public class JPAMybatisPlusGenerator implements IdentifierGenerator {
+public class JPAGenerator implements IdentifierGenerator {
     @Override
     public Serializable generate(SharedSessionContractImplementor sharedSessionContractImplementor, Object o) throws HibernateException {
         return Core.INSTANCE.generate();

--- a/src/main/java/com/github/hexdude/generator/MybatisPlusGenerator.java
+++ b/src/main/java/com/github/hexdude/generator/MybatisPlusGenerator.java
@@ -1,0 +1,20 @@
+package com.github.hexdude.generator;
+
+import com.baomidou.mybatisplus.core.incrementer.IdentifierGenerator;
+import com.github.hexdude.core.Core;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author HEXDude
+ * @date 2022/3/21
+ * @description Customized Primary Key generating strategy for JPA(Hibernate).
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+@Component
+public class MybatisPlusGenerator implements IdentifierGenerator {
+
+    @Override
+    public Number nextId(Object entity) {
+        return Core.INSTANCE.generate();
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+#Enable AUTO INJECT DEFINED BEANS TO TARGET CONTAINER
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.github.hexdude.property.Configuration


### PR DESCRIPTION
1. Seprated JPA and MybatisPlus primary key strategy as in two class.
2. Fixed unable to injection bean to references'  containner #3 .